### PR TITLE
fix schema

### DIFF
--- a/db/migrate/20210219105355_remove_name_from_services.rb
+++ b/db/migrate/20210219105355_remove_name_from_services.rb
@@ -1,5 +1,0 @@
-class RemoveNameFromServices < ActiveRecord::Migration[6.0]
-  def change
-    remove_column :services, :name, :string
-  end
-end

--- a/db/migrate/20210219105537_remove_category_from_services.rb
+++ b/db/migrate/20210219105537_remove_category_from_services.rb
@@ -1,5 +1,0 @@
-class RemoveCategoryFromServices < ActiveRecord::Migration[6.0]
-  def change
-    remove_column :services, :category, :string
-  end
-end

--- a/db/migrate/20210219105922_add_columns_to_services.rb
+++ b/db/migrate/20210219105922_add_columns_to_services.rb
@@ -1,7 +1,0 @@
-class AddColumnsToServices < ActiveRecord::Migration[6.0]
-  def change
-    add_column :services, :title, :string
-    add_column :services, :description, :text
-    add_reference :services, :category, null: false, foreign_key: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -68,31 +68,6 @@ ActiveRecord::Schema.define(version: 2021_02_24_095524) do
     t.index ["professional_id"], name: "index_offers_on_professional_id"
   end
 
-  create_table "reviews", force: :cascade do |t|
-    t.text "content"
-    t.integer "rating"
-    t.bigint "service_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["service_id"], name: "index_reviews_on_service_id"
-  end
-
-  create_table "services", force: :cascade do |t|
-    t.datetime "start_at"
-    t.datetime "end_at"
-    t.string "localization"
-    t.bigint "author_id", null: false
-    t.bigint "consumer_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.string "title"
-    t.text "description"
-    t.bigint "category_id", null: false
-    t.index ["author_id"], name: "index_services_on_author_id"
-    t.index ["category_id"], name: "index_services_on_category_id"
-    t.index ["consumer_id"], name: "index_services_on_consumer_id"
-  end
-
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -116,8 +91,4 @@ ActiveRecord::Schema.define(version: 2021_02_24_095524) do
   add_foreign_key "bookings", "users", column: "professional_id"
   add_foreign_key "offers", "categories"
   add_foreign_key "offers", "users", column: "professional_id"
-  add_foreign_key "reviews", "services"
-  add_foreign_key "services", "categories"
-  add_foreign_key "services", "users", column: "author_id"
-  add_foreign_key "services", "users", column: "consumer_id"
 end


### PR DESCRIPTION
Malgré les `rails d model reviews`, et les `rails d model services`, les 2 tables apparaissaient toujours dans le **schema.rb**
J'ai donc `drop`/ `create`/ `migrate` la db pour que le schéma soit correct ...
Je suis assez perplexe sur cette manip ?!
